### PR TITLE
37 sender label

### DIFF
--- a/Phlash.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Phlash.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:">
+      location = "self:Phlash.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Phlash/PhlashView.swift
+++ b/Phlash/PhlashView.swift
@@ -12,6 +12,7 @@ class PhlashView: UIImageView {
     
     private let screenBounds:CGSize = UIScreen.mainScreen().bounds.size
     private let whiteColor = UIColor.whiteColor()
+    private let blackColor = UIColor.blackColor()
     var identificationLabel = UILabel()
     let usernameLabel = UILabel()
     let captionLabel = UILabel()
@@ -20,8 +21,8 @@ class PhlashView: UIImageView {
         super.init(frame:frame)
         backgroundColor = UIColor.clearColor()
         addIdLabel()
-        addusernameLabel()
-        addcaptionLabel()
+        addUsernameLabel()
+        addCaptionLabel()
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -36,19 +37,19 @@ class PhlashView: UIImageView {
         addSubview(identificationLabel)
     }
     
-    func addusernameLabel() {
-        usernameLabel.frame = CGRect(x: 0, y: screenBounds.height/8, width: self.frame.width, height: screenBounds.height/15)
-        usernameLabel.backgroundColor = UIColor.colorWithAlphaComponent(whiteColor)(0.5)
-        usernameLabel.textColor = UIColor.blackColor()
+    func addUsernameLabel() {
+        usernameLabel.frame = CGRect(x: 0, y: screenBounds.height*16/17, width: self.frame.width, height: screenBounds.height/17)
+        usernameLabel.backgroundColor = UIColor.colorWithAlphaComponent(blackColor)(0.4)
+        usernameLabel.textColor = whiteColor
         usernameLabel.textAlignment = .Center
         usernameLabel.userInteractionEnabled = false
         addSubview(usernameLabel)
     }
     
-    func addcaptionLabel() {
+    func addCaptionLabel() {
         captionLabel.frame = CGRect(x: 0, y: screenBounds.height/5, width: self.frame.width, height: screenBounds.height/15)
         captionLabel.backgroundColor = UIColor.colorWithAlphaComponent(whiteColor)(0.5)
-        captionLabel.textColor = UIColor.blackColor()
+        captionLabel.textColor = blackColor
         captionLabel.textAlignment = .Center
         captionLabel.userInteractionEnabled = false
         addSubview(captionLabel)

--- a/Phlash/PhlashView.swift
+++ b/Phlash/PhlashView.swift
@@ -39,6 +39,7 @@ class PhlashView: UIImageView {
     
     func addUsernameLabel() {
         usernameLabel.frame = CGRect(x: 0, y: screenBounds.height*16/17, width: self.frame.width, height: screenBounds.height/17)
+        usernameLabel.font = UIFont.systemFontOfSize(screenBounds.height/35)
         usernameLabel.backgroundColor = UIColor.colorWithAlphaComponent(blackColor)(0.4)
         usernameLabel.textColor = whiteColor
         usernameLabel.textAlignment = .Center


### PR DESCRIPTION
Closes #37 

Sender Label moved to bottom of photo and changed to black (0.4 alpha) so that it is less obvious, and the focus is more on the photo and the caption.
Font size added which is relative to screen height.
