### PR TITLE
Edited lastSeen save and date

### DIFF
--- a/Phlash/CameraController.swift
+++ b/Phlash/CameraController.swift
@@ -102,9 +102,8 @@ class CameraViewController: UIViewController, UIImagePickerControllerDelegate, U
     func showPhlash() {
         if phlashesArray.count > 0 {
             let firstPhlash = phlashesArray.first!
-            NSUserDefaults.standardUserDefaults().setObject(firstPhlash.createdAt, forKey: "lastSeen")
-            phlashesArray.removeAtIndex(0)
             RetrievePhoto().showFirstPhlashImage(cameraView, firstPhlash: firstPhlash)
+            phlashesArray.removeAtIndex(0)
         } else {
             AlertMessage().show(statusLabel, message: "No phlashes! Try again later.")
         }

--- a/Phlash/RetrievePhoto.swift
+++ b/Phlash/RetrievePhoto.swift
@@ -29,14 +29,12 @@ class RetrievePhoto {
     
     func queryDatabaseForPhotos(getPhlashes: (phlashesFromDatabase : [PFObject]?, error : NSError?) -> Void) {
         let defaults = NSUserDefaults.standardUserDefaults()
-        var lastSeenDate = NSDate()
+        let dateInPast = NSDate(timeIntervalSinceReferenceDate: 0)
+        var lastSeenDate = dateInPast
         
-        if defaults.objectForKey("lastSeen") == nil {
-            lastSeenDate = NSCalendar.currentCalendar().dateByAddingUnit(NSCalendarUnit.Month, value: -1, toDate: NSDate(), options: NSCalendarOptions.init(rawValue: 0))!
-        } else {
+        if defaults.objectForKey("lastSeen") != nil {
             lastSeenDate = defaults.objectForKey("lastSeen") as! NSDate
         }
-        
         
         let currentUser = PFUser.currentUser()
         let currentUsername = currentUser!.username!
@@ -54,6 +52,11 @@ class RetrievePhoto {
             (results: [PFObject]?, error: NSError?) -> Void in
             if error == nil {
                 getPhlashes(phlashesFromDatabase: results, error: error)
+                if results!.count > 0 {
+                    NSUserDefaults.standardUserDefaults().setObject(results!.last!.createdAt, forKey: "lastSeen")
+                } else {
+                    NSUserDefaults.standardUserDefaults().setObject(NSDate(), forKey: "lastSeen")
+                }
             }
         }
     }

--- a/Phlash/UserAuthentication.swift
+++ b/Phlash/UserAuthentication.swift
@@ -12,8 +12,6 @@ class UserAuthentication {
     
     func signUp(controller: UIViewController, username: String, email: String, password: String, statusLabel: UILabel) {
         
-       // let twentyFourHoursSince = NSDate(timeIntervalSinceReferenceDate: -86400.0)
-        
         let user = PFUser()
         user.username = username
         user.password = password


### PR DESCRIPTION
Closes #70 

If no `lastSeen` saved in `NSUserDefaults`, then use the "reference date" which is 1st January 2001.

When query database, if there is at least 1 phlash, set the `lastSeen` to equal the `phlashesArray.last.createdAt` datetime. If no phlashes, set datetime to equal right now. 
